### PR TITLE
Change messanger adapter to work with instagram

### DIFF
--- a/examples/insta-bot/.gitignore
+++ b/examples/insta-bot/.gitignore
@@ -1,0 +1,7 @@
+node_modules
+dist
+tsconfig.tsbuildinfo
+.vscode
+yarn-error.log
+.DS_Store
+.env

--- a/examples/insta-bot/package.json
+++ b/examples/insta-bot/package.json
@@ -1,0 +1,21 @@
+{
+    "name": "@ebenos/insta-bot",
+    "version": "4.0.0-alpha.27",
+    "main": "./dist/server.js",
+    "license": "MIT",
+    "private": true,
+    "scripts": {
+        "start": "yarn node ./dist/server.js",
+        "build": "yarn tsc",
+        "dev": "yarn run build && yarn start",
+        "fb:config": "yarn node ./dist/scripts/install.js",
+        "lint": "yarn eslint '*/**/*.ts' --quiet --fix -c ../../.eslintrc.js --ignore-path ../../.eslintignore"
+    },
+    "dependencies": {
+        "@ebenos/elements": "^4.0.0-alpha.27",
+        "@ebenos/framework": "^4.0.0-alpha.27",
+        "@types/node-fetch": "^2.5.8",
+        "body-parser": "^1.19.0",
+        "node-fetch": "^2.6.1"
+    }
+}

--- a/examples/insta-bot/src/bot.ts
+++ b/examples/insta-bot/src/bot.ts
@@ -1,0 +1,11 @@
+import { Bot, InMemoryUser, inMemoryUserLoader } from '@ebenos/framework';
+import { fbConfig } from './secret';
+import { MessengerAdapter } from '@ebenos/messenger-adapter';
+
+import getStarted from './modules/getStarted';
+
+export const adapter = new MessengerAdapter(fbConfig, inMemoryUserLoader());
+
+export const bot = new Bot<InMemoryUser>(adapter, {});
+
+bot.addModule(getStarted);

--- a/examples/insta-bot/src/modules/getStarted/actions.ts
+++ b/examples/insta-bot/src/modules/getStarted/actions.ts
@@ -1,0 +1,25 @@
+import { bot } from '../../bot';
+import { Message } from '@ebenos/elements';
+import { addAction, addTextRule, InMemoryUser } from '@ebenos/framework';
+import getStartedModule from '.';
+
+const DELAY = 10;
+
+addAction(getStartedModule, getStarted);
+addTextRule(getStartedModule, getStarted, /TESTINSTA/);
+async function getStarted(user: InMemoryUser) {
+    return bot
+        .scenario(user)
+        .send(
+            new Message({
+                text: `Hi there!!! 😄`
+            })
+        )
+        .wait(DELAY)
+        .send(
+            new Message({
+                text: 'Now I am on instagram too.'
+            })
+        )
+        .end();
+}

--- a/examples/insta-bot/src/modules/getStarted/index.ts
+++ b/examples/insta-bot/src/modules/getStarted/index.ts
@@ -1,0 +1,7 @@
+import { createModule, InMemoryUser, Module } from '@ebenos/framework';
+
+const getStartedModule: Module<InMemoryUser> = createModule('getStarted');
+
+export default getStartedModule;
+
+import './actions';

--- a/examples/insta-bot/src/secret.ts
+++ b/examples/insta-bot/src/secret.ts
@@ -1,0 +1,30 @@
+import dotenv from 'dotenv';
+dotenv.config();
+
+const FB_PAGE_ID = process.env.FB_PAGE_ID;
+if (!FB_PAGE_ID) {
+    throw new Error('Missing env: No FB_PAGE_ID');
+}
+
+const FB_PAGE_TOKEN = process.env.FB_PAGE_TOKEN;
+if (!FB_PAGE_TOKEN) {
+    throw new Error('Missing env: No FB_PAGE_TOKEN');
+}
+
+const FB_APP_SECRET = process.env.FB_APP_SECRET;
+if (!FB_APP_SECRET) {
+    throw new Error('Missing env: No FB_APP_SECRET');
+}
+
+const FB_APP_ID = process.env.FB_APP_ID;
+if (!FB_APP_ID) {
+    throw new Error('Missing env: No FB_APP_ID');
+}
+
+export const fbConfig = {
+    pageId: FB_PAGE_ID,
+    pageToken: FB_PAGE_TOKEN,
+    appSecret: FB_APP_SECRET,
+    app_id: FB_APP_ID,
+    webhookKey: '123'
+};

--- a/examples/insta-bot/src/server.ts
+++ b/examples/insta-bot/src/server.ts
@@ -1,0 +1,10 @@
+import { adapter } from './bot';
+
+adapter.webhook.listen(3002);
+console.log('Listening...');
+
+console.log('Setting up webhook...');
+
+(async () => {
+    console.log('Ready!');
+})();

--- a/examples/insta-bot/tsconfig.json
+++ b/examples/insta-bot/tsconfig.json
@@ -1,0 +1,69 @@
+{
+  "compilerOptions": {
+    /* Basic Options */
+    // "incremental": true,                   /* Enable incremental compilation */
+    "target": "ES2015" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019' or 'ESNEXT'. */,
+    "module": "commonjs" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */,
+    // "lib": [],                             /* Specify library files to be included in the compilation. */
+    // "allowJs": true,                       /* Allow javascript files to be compiled. */
+    // "checkJs": true,                       /* Report errors in .js files. */
+    // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
+    "declaration": true /* Generates corresponding '.d.ts' file. */,
+    "declarationMap": true /* Generates a sourcemap for each corresponding '.d.ts' file. */,
+    "sourceMap": true /* Generates corresponding '.map' file. */,
+    // "outFile": "./",                       /* Concatenate and emit output to single file. */
+    "outDir": "./dist" /* Redirect output structure to the directory. */,
+    "rootDir": "src" /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */,
+    // "composite": true,                     /* Enable project compilation */
+    // "tsBuildInfoFile": "./",               /* Specify file to store incremental compilation information */
+    // "removeComments": true,                /* Do not emit comments to output. */
+    // "noEmit": true,                        /* Do not emit outputs. */
+    // "importHelpers": true,                 /* Import emit helpers from 'tslib'. */
+    // "downlevelIteration": true,            /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
+    // "isolatedModules": true,               /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
+
+    /* Strict Type-Checking Options */
+    "strict": true /* Enable all strict type-checking options. */,
+    "noImplicitAny": true /* Raise error on expressions and declarations with an implied 'any' type. */,
+    "strictNullChecks": true /* Enable strict null checks. */,
+    "strictFunctionTypes": true /* Enable strict checking of function types. */,
+    "strictBindCallApply": true /* Enable strict 'bind', 'call', and 'apply' methods on functions. */,
+    "strictPropertyInitialization": true /* Enable strict checking of property initialization in classes. */,
+    "noImplicitThis": true /* Raise error on 'this' expressions with an implied 'any' type. */,
+    "alwaysStrict": true /* Parse in strict mode and emit "use strict" for each source file. */,
+
+    /* Additional Checks */
+    // "noUnusedLocals": true,                /* Report errors on unused locals. */
+    // "noUnusedParameters": true,            /* Report errors on unused parameters. */
+    "noImplicitReturns": true /* Report error when not all code paths in function return a value. */,
+    "noFallthroughCasesInSwitch": true /* Report errors for fallthrough cases in switch statement. */,
+
+    /* Module Resolution Options */
+    "moduleResolution": "node" /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */,
+    "baseUrl": "./dist" /* Base directory to resolve non-absolute module names. */,
+    // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
+    "rootDirs": [
+      "./src/"
+    ] /* List of root folders whose combined content represents the structure of the project at runtime. */,
+    // "typeRoots": [],                       /* List of folders to include type definitions from. */
+    // "types": [],                           /* Type declaration files to be included in compilation. */
+    // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
+    "esModuleInterop": true /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */,
+    // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
+    // "allowUmdGlobalAccess": true,          /* Allow accessing UMD globals from modules. */
+
+    /* Source Map Options */
+    // "sourceRoot": "",                      /* Specify the location where debugger should locate TypeScript files instead of source locations. */
+    // "mapRoot": "",                         /* Specify the location where debugger should locate map files instead of generated locations. */
+    // "inlineSourceMap": true,               /* Emit a single file with source maps instead of having a separate file. */
+    // "inlineSources": true,                 /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
+
+    /* Experimental Options */
+    // "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
+    // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
+
+    /* Advanced Options */
+    "forceConsistentCasingInFileNames": true /* Disallow inconsistently-cased references to the same file. */
+  },
+  "include": ["./src/**/*"]
+}

--- a/packages/messenger-adapter/lib/adapter/adapter.ts
+++ b/packages/messenger-adapter/lib/adapter/adapter.ts
@@ -1,5 +1,5 @@
 import { GenericAdapter, IInteraction } from '@ebenos/framework';
-import { Request, Response, RequestHandler, Router } from 'express';
+import express, { Request, Response, RequestHandler, Express } from 'express';
 
 import webhook from './webhook';
 import { senderFactory, SenderFunction } from './sender';
@@ -32,7 +32,7 @@ export default class MessengerAdapter extends GenericAdapter<MessengerOperations
         actions: Array<IInteraction<MessagingOptions>>,
         type: 'ORDERED' | 'UNORDERED'
     ) => Promise<void>;
-    public webhook: Router;
+    public webhook: Express;
 
     constructor(
         options: MessengerWebhookOptions,
@@ -54,7 +54,7 @@ export default class MessengerAdapter extends GenericAdapter<MessengerOperations
         this.operations = {
             handover
         };
-        this.webhook = Router();
+        this.webhook = express();
         this.webhook.use(bodyParser.json());
 
         if (userLoader) {

--- a/packages/messenger-adapter/lib/adapter/webhook.ts
+++ b/packages/messenger-adapter/lib/adapter/webhook.ts
@@ -14,7 +14,7 @@ export default function webhook(
     return (req: Request, res: Response) => {
         res.sendStatus(200);
         const data = req.body as MessengerWebhookBody;
-        if (data.object === 'page') {
+        if (data.object === 'page' || data.object === 'instagram') {
             data.entry.forEach((e) => {
                 // Main messaging webhook
                 if (e.messaging) {


### PR DESCRIPTION
- Add insta-bot example to test the new insta feature
- Messenger adapter.webhook to return the app ( in order to be the same with viber adapter)
- Messenger to handle requests coming from Instagram as well as Facebook (data.object = page, data.object = Instagram )