### PR TITLE
Tracking data

### DIFF
--- a/examples/viber-demo-bot/src/modules/getStarted/actions.ts
+++ b/examples/viber-demo-bot/src/modules/getStarted/actions.ts
@@ -138,8 +138,6 @@ async function getTest8(user: InMemoryUser) {
 addAction(getStartedModule, test_tracking);
 addPostbackRule(getStartedModule, test_tracking, 'object');
 async function test_tracking(user: InMemoryUser, payload: { tracking_data: any; text: string }) {
-    console.log(payload.text);
-    console.log(payload.tracking_data);
     await bot
         .scenario(user)
         .send(

--- a/examples/viber-demo-bot/src/modules/getStarted/actions.ts
+++ b/examples/viber-demo-bot/src/modules/getStarted/actions.ts
@@ -1,7 +1,7 @@
 import { bot } from '../../bot';
 import { RichMedia, Button, Message } from '@ebenos/viber-elements';
 import { Carousel } from '@ebenos/viber-elements';
-import { addAction, addTextRule, InMemoryUser } from '@ebenos/framework';
+import { addAction, addPostbackRule, addTextRule, InMemoryUser } from '@ebenos/framework';
 import getStartedModule from '.';
 
 const testArray = [
@@ -39,7 +39,7 @@ const testArray = [
 
 addAction(getStartedModule, getTest6);
 addTextRule(getStartedModule, getTest6, /TEST6/);
-async function getTest6(user: InMemoryUser, payload: string) {
+async function getTest6(user: InMemoryUser) {
     await bot
         .scenario(user)
         .send(
@@ -105,7 +105,7 @@ const staticButtons = [
 
 addAction(getStartedModule, getTest7);
 addTextRule(getStartedModule, getTest7, /TEST7/);
-async function getTest7(user: InMemoryUser, payload: string) {
+async function getTest7(user: InMemoryUser) {
     await bot
         .scenario(user)
         .send(
@@ -121,7 +121,7 @@ async function getTest7(user: InMemoryUser, payload: string) {
 
 addAction(getStartedModule, getTest8);
 addTextRule(getStartedModule, getTest8, /TEST9/);
-async function getTest8(user: InMemoryUser, payload: string) {
+async function getTest8(user: InMemoryUser) {
     await bot
         .scenario(user)
         .send(
@@ -135,18 +135,58 @@ async function getTest8(user: InMemoryUser, payload: string) {
         .end();
 }
 
-addAction(getStartedModule, getStartedSecond);
-addTextRule(getStartedModule, getStartedSecond, /.*/);
-async function getStartedSecond(user: InMemoryUser, payload: string) {
-    console.log(payload);
-    const now = new Date();
+addAction(getStartedModule, test_tracking);
+addPostbackRule(getStartedModule, test_tracking, 'object');
+async function test_tracking(user: InMemoryUser, payload: { tracking_data: any; text: string }) {
+    console.log(payload.text);
+    console.log(payload.tracking_data);
     await bot
         .scenario(user)
         .send(
             new Message({
-                text: `${now.toISOString()} Second`,
                 sender: {
-                    name: 'Christos'
+                    name: 'Giorgos'
+                },
+                text: 'Yes, I got the tracking data: ' + payload.tracking_data.age
+            })
+        )
+        .end();
+}
+
+addAction(getStartedModule, getTest11);
+addTextRule(getStartedModule, getTest11, /TEST11/);
+async function getTest11(user: InMemoryUser) {
+    await bot
+        .scenario(user)
+        .send(
+            new Message({
+                sender: {
+                    name: 'Giorgos'
+                },
+                text: 'send something with tracking data',
+                tracking_data: {
+                    type: 'getStarted/test_tracking',
+                    isPostback: true,
+                    age: 18
+                }
+            })
+        )
+        .end();
+}
+
+addAction(getStartedModule, getTest12);
+addTextRule(getStartedModule, getTest12, /TEST12/);
+async function getTest12(user: InMemoryUser) {
+    await bot
+        .scenario(user)
+        .send(
+            new Message({
+                sender: {
+                    name: 'Giorgos'
+                },
+                text: 'send something with tracking data',
+                tracking_data: {
+                    age: 18
                 }
             })
         )

--- a/packages/framework/lib/adapter.ts
+++ b/packages/framework/lib/adapter.ts
@@ -5,6 +5,7 @@ import { GenericAttachment } from './interfaces/attachment';
 import { WitNLP } from './interfaces/nlp';
 import { ISerializable } from '.';
 import { IInteraction } from './interfaces/interactions';
+import { ITrackingData } from './interfaces/trackingData';
 // TODO: Add all
 export interface IRouters {
     PostbackRouter?: PostbackRouter;
@@ -15,7 +16,7 @@ export interface IRouters {
 export interface EbonyHandlers<U> {
     attachment?: (user: U, attachment: GenericAttachment) => Promise<any>;
     text?: (
-        message: { text: string; tracking_data?: string | { [key: string]: string } },
+        message: { text: string; tracking_data?: ITrackingData },
         nlp: WitNLP | undefined,
         user: U
     ) => Promise<any>;

--- a/packages/framework/lib/adapter.ts
+++ b/packages/framework/lib/adapter.ts
@@ -14,7 +14,11 @@ export interface IRouters {
 
 export interface EbonyHandlers<U> {
     attachment?: (user: U, attachment: GenericAttachment) => Promise<any>;
-    text?: (message: { text: string }, nlp: WitNLP | undefined, user: U) => Promise<any>;
+    text?: (
+        message: { text: string; tracking_data?: string | { [key: string]: string } },
+        nlp: WitNLP | undefined,
+        user: U
+    ) => Promise<any>;
 }
 
 export interface IBaseMessageOptions {

--- a/packages/framework/lib/bot.ts
+++ b/packages/framework/lib/bot.ts
@@ -147,7 +147,7 @@ export default class Bot<U extends User<any>> {
         for (const r of rules) {
             textRules.push({
                 regex: r.regex,
-                action: (user: U, payload: string) => bot.actions.exec(r.action, user, payload)
+                action: (user: U, payload: object) => bot.actions.exec(r.action, user, payload)
             });
         }
 

--- a/packages/framework/lib/handlers/text.ts
+++ b/packages/framework/lib/handlers/text.ts
@@ -12,6 +12,7 @@ import TextMatcher from '../routers/TextMatcher';
 import User from '../models/User';
 import { WitNLP } from '../interfaces/nlp';
 import Bot from '../bot';
+import { ITrackingData } from '../interfaces/trackingData';
 
 /**
  * @param {TextMatcher} matcher - A TextMatcher Instance
@@ -35,7 +36,7 @@ export default function textHandlerFactory<U extends User<any>>(
 ) {
     function textHandler(
         this: Bot<U>,
-        message: { text: string; tracking_data?: { [key: string]: string } | string },
+        message: { text: string; tracking_data?: ITrackingData },
         nlp: WitNLP | undefined,
         user: U
     ) {

--- a/packages/framework/lib/handlers/text.ts
+++ b/packages/framework/lib/handlers/text.ts
@@ -35,13 +35,15 @@ export default function textHandlerFactory<U extends User<any>>(
 ) {
     function textHandler(
         this: Bot<U>,
-        message: { text: string },
+        message: { text: string; tracking_data?: { [key: string]: string } | string },
         nlp: WitNLP | undefined,
         user: U
     ) {
         const action = matcher.ruleMatcher(message);
         if (action) {
-            return action(user, message.text);
+            // This is needs a check when we update on this version
+            // Cause now second argument is an object and not just a string
+            return action(user, message);
         }
 
         if (nlp) {

--- a/packages/framework/lib/interfaces/trackingData.ts
+++ b/packages/framework/lib/interfaces/trackingData.ts
@@ -1,13 +1,5 @@
-type TrackingDataObj = Record<
-    string,
-    | number
-    | string
-    | boolean
-    | Array<TrackingDataObj | string | number | boolean>
-    | TrackingDataCopy
->;
-// this is realy a work around cause of the ts version
-// eslint-disable-next-line @typescript-eslint/no-empty-interface
-interface TrackingDataCopy extends TrackingDataObj {}
-
-export type ITrackingData = TrackingDataObj | string;
+export type TrackingDataPrimitives = null | string | number | boolean;
+export type ITrackingData =
+    | TrackingDataPrimitives
+    | Array<TrackingDataPrimitives | ITrackingData>
+    | { [key: string]: ITrackingData };

--- a/packages/framework/lib/interfaces/trackingData.ts
+++ b/packages/framework/lib/interfaces/trackingData.ts
@@ -1,5 +1,5 @@
 export type TrackingDataPrimitives = null | string | number | boolean;
 export type ITrackingData =
     | TrackingDataPrimitives
-    | Array<TrackingDataPrimitives | ITrackingData>
+    | Array<ITrackingData>
     | { [key: string]: ITrackingData };

--- a/packages/framework/lib/interfaces/trackingData.ts
+++ b/packages/framework/lib/interfaces/trackingData.ts
@@ -1,0 +1,13 @@
+type TrackingDataObj = Record<
+    string,
+    | number
+    | string
+    | boolean
+    | Array<TrackingDataObj | string | number | boolean>
+    | TrackingDataCopy
+>;
+// this is realy a work around cause of the ts version
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+interface TrackingDataCopy extends TrackingDataObj {}
+
+export type ITrackingData = TrackingDataObj | string;

--- a/packages/framework/lib/modules/index.ts
+++ b/packages/framework/lib/modules/index.ts
@@ -71,7 +71,7 @@ export function addPostbackRule<U extends User<any>>(
 
 export function addTextRule<U extends User<any>>(
     module: Module<U>,
-    action: (user: U, param: object) => Promise<any>,
+    action: (user: U, message?: Record<string, any>, ...args: any[]) => Promise<any>,
     rule: RegExp | RegExp[]
 ): void {
     const actionName = module.name + '/' + action.name;

--- a/packages/framework/lib/modules/index.ts
+++ b/packages/framework/lib/modules/index.ts
@@ -71,7 +71,7 @@ export function addPostbackRule<U extends User<any>>(
 
 export function addTextRule<U extends User<any>>(
     module: Module<U>,
-    action: (user: U, ...args: any[]) => Promise<any>,
+    action: (user: U, param: object) => Promise<any>,
     rule: RegExp | RegExp[]
 ): void {
     const actionName = module.name + '/' + action.name;

--- a/packages/framework/lib/routers/TextMatcher.ts
+++ b/packages/framework/lib/routers/TextMatcher.ts
@@ -10,7 +10,7 @@
 
 export interface ITextRule {
     regex: RegExp;
-    action: (user: any, param: object) => any;
+    action: (user: any, message?: Record<string, any>, ...args: any[]) => any;
 }
 
 /**
@@ -26,7 +26,9 @@ export default class TextMatcher {
         this.rules = this.rules.concat(rules);
     }
 
-    public ruleMatcher(message: { text: string }): ((user: any, param: object) => any) | false {
+    public ruleMatcher(message: {
+        text: string;
+    }): ((user: any, message?: Record<string, any>, ...args: any[]) => any) | false {
         const msg = message.text.toUpperCase();
         for (const rule of this.rules) {
             const { regex, action } = rule;

--- a/packages/framework/lib/routers/TextMatcher.ts
+++ b/packages/framework/lib/routers/TextMatcher.ts
@@ -10,7 +10,7 @@
 
 export interface ITextRule {
     regex: RegExp;
-    action: (user: any, ...param: any[]) => any;
+    action: (user: any, param: object) => any;
 }
 
 /**
@@ -26,7 +26,7 @@ export default class TextMatcher {
         this.rules = this.rules.concat(rules);
     }
 
-    public ruleMatcher(message: { text: string }): ((user: any, ...param: any[]) => any) | false {
+    public ruleMatcher(message: { text: string }): ((user: any, param: object) => any) | false {
         const msg = message.text.toUpperCase();
         for (const rule of this.rules) {
             const { regex, action } = rule;

--- a/packages/viber-adapter/lib/adapter.ts
+++ b/packages/viber-adapter/lib/adapter.ts
@@ -96,18 +96,16 @@ function handleTextMessage(
 ) {
     try {
         const parsedTrackingData = JSON.parse(m.tracking_data) as unknown;
-        if (isPostbackTrackingData(parsedTrackingData)) {
-            const payload = JSON.stringify({
-                type: parsedTrackingData.type,
-                text: m.text,
-                tracking_data: parsedTrackingData
-            });
-            console.log(routerExists(routers.PostbackRouter));
-            routerExists(routers.PostbackRouter).objectPayloadHandler(payload, user);
+        if (!isPostbackTrackingData(parsedTrackingData)) {
+            handleTextOnly(m, user, textHandler);
             return;
         }
-
-        handleTextOnly(m, user, textHandler);
+        const payload = JSON.stringify({
+            type: parsedTrackingData.type,
+            text: m.text,
+            tracking_data: parsedTrackingData
+        });
+        routerExists(routers.PostbackRouter).objectPayloadHandler(payload, user);
         return;
     } catch {
         handleTextOnly(m, user, textHandler);

--- a/packages/viber-adapter/lib/adapter.ts
+++ b/packages/viber-adapter/lib/adapter.ts
@@ -72,13 +72,20 @@ function handleTextOnly(
     user: IUser,
     textHandler: EbonyHandlers<any>['text']
 ) {
-    if (textHandler !== undefined) {
-        textHandler({ text: m.text }, undefined, user);
+    if (textHandler === undefined) {
+        console.log('No text handler');
         return;
     }
-
-    console.log('No text handler');
-    return;
+    try {
+        // tracking_data can be an object
+        const parsedTrackingData = JSON.parse(m.tracking_data) as { [key: string]: string };
+        textHandler({ text: m.text, tracking_data: parsedTrackingData }, undefined, user);
+        return;
+    } catch {
+        // or string
+        textHandler({ text: m.text, tracking_data: m.tracking_data }, undefined, user);
+        return;
+    }
 }
 
 function handleTextMessage(
@@ -91,9 +98,11 @@ function handleTextMessage(
         const parsedTrackingData = JSON.parse(m.tracking_data) as unknown;
         if (isPostbackTrackingData(parsedTrackingData)) {
             const payload = JSON.stringify({
-                type: parsedTrackingData.type + m.text.replace(' ', ''),
-                data: parsedTrackingData.data
+                type: parsedTrackingData.type,
+                text: m.text,
+                tracking_data: parsedTrackingData
             });
+            console.log(routerExists(routers.PostbackRouter));
             routerExists(routers.PostbackRouter).objectPayloadHandler(payload, user);
             return;
         }

--- a/packages/viber-elements/lib/viberAPI/interfaces.ts
+++ b/packages/viber-elements/lib/viberAPI/interfaces.ts
@@ -1,6 +1,7 @@
 import { RichMedia, Picture, Button } from './attachments';
 import { Carousel } from './carousel';
 import { Keyboard } from './keyboard';
+import { ITrackingData } from '@ebenos/framework/lib/interfaces/trackingData';
 
 export type ScaleType = 'crop' | 'fill' | 'fit';
 export type ActionType = 'reply' | 'open-url' | 'location-picker' | 'share-phone' | 'none';
@@ -45,7 +46,7 @@ export interface ISender {
 
 export interface IGeneralMessageOptions {
     sender: ISender;
-    tracking_data?: string | Record<string, any>;
+    tracking_data?: ITrackingData;
     keyboard?: Keyboard;
     attachment?: Picture;
 }

--- a/packages/viber-elements/lib/viberAPI/message.ts
+++ b/packages/viber-elements/lib/viberAPI/message.ts
@@ -12,6 +12,7 @@ import {
 import { Picture, RichMedia } from './attachments';
 import { Keyboard } from './keyboard';
 import { Carousel } from './carousel';
+import { ITrackingData } from '@ebenos/framework/lib/interfaces/trackingData';
 
 function isText(options: IMessageOptions): options is ITextOptions {
     return (options as ITextOptions).text !== undefined;
@@ -26,7 +27,7 @@ function isRichMedia(options: IMessageOptions): options is IRichMediaMessageOpti
 /** Message Class */
 export class Message implements ISerializable {
     public sender: ISender;
-    public tracking_data?: string | Record<string, any>;
+    public tracking_data?: ITrackingData;
     public type: MessageType;
     public text?: string;
     public attachment?: Picture;


### PR DESCRIPTION
# Push Tracking Data throw text handler

### A quick explanation on how will tracking data will be treated.

In each viber call we can send to the user, as well as a normal viber message, some tracking data in order for them to be passed back to us when he sends a new message to us. 

We are using tracking data in two ways. 

#### 1. To create a post back route. 
What ever the user sends back, we will handly using first the post back action.
This is archived by adding the following two properties to the tracking data

> `type: string` The action name to post back
> `isPostback: boolean` set to true for a post back

#### 2. To push data in the next call.
We can collect temp data from the user's actions and pass them around in the calls to enhance the experience.
Tracking data can be an object or a simple string.


This two ways can work together. So a tracking data object can have type and isPostback:true and then any property that we need to send back. The tracking data param is passed to the action function as well as the text send by the user