### PR TITLE
Viber location msg

### DIFF
--- a/examples/viber-demo-bot/src/modules/getStarted/actions.ts
+++ b/examples/viber-demo-bot/src/modules/getStarted/actions.ts
@@ -1,7 +1,7 @@
 import { bot } from '../../bot';
 import { RichMedia, Button, Message } from '@ebenos/viber-elements';
 import { Carousel } from '@ebenos/viber-elements';
-import { addAction, addTextRule, InMemoryUser } from '@ebenos/framework';
+import { addAction, addTextRule, InMemoryUser, addLocationBaseAction } from '@ebenos/framework';
 import getStartedModule from '.';
 
 const testArray = [
@@ -130,6 +130,23 @@ async function getTest8(user: InMemoryUser, payload: string) {
                     name: 'Giorgos'
                 },
                 media: 'https://upload.wikimedia.org/wikipedia/commons/2/2c/Rotating_earth_%28large%29.gif'
+            })
+        )
+        .end();
+}
+addAction(getStartedModule, location);
+addLocationBaseAction(getStartedModule, location);
+async function location(user: InMemoryUser, payload: { location: any }) {
+    console.log(payload);
+    const now = new Date();
+    await bot
+        .scenario(user)
+        .send(
+            new Message({
+                text: `Yes i got the location ` + payload.location,
+                sender: {
+                    name: 'Christos'
+                }
             })
         )
         .end();

--- a/packages/framework/lib/modules/index.ts
+++ b/packages/framework/lib/modules/index.ts
@@ -89,6 +89,26 @@ export function addTextRule<U extends User<any>>(
     }
 }
 
+export function addLocationBaseAction<U extends User<any>>(
+    module: Module<U>,
+    action: (user: U, ...args: any[]) => Promise<any>
+): void {
+    const rule = /USER_SEND_LOCATION/;
+    const actionName = module.name + '/' + action.name;
+    if (module.actions === undefined || !(actionName in module.actions)) {
+        throw new Error(`Action with name: '${actionName}', doesn't exist!`);
+    }
+    if (module.text === undefined) {
+        module.text = [];
+    }
+
+    if (Array.isArray(rule)) {
+        module.text.concat(rule.map((r) => ({ regex: r, action: actionName })));
+    } else {
+        module.text.push({ regex: rule, action: actionName });
+    }
+}
+
 export function createPayload<U extends User<any>>(
     module: Module<U>,
     action: (user: U, payload?: any, ...args: any[]) => Promise<any>,

--- a/packages/viber-adapter/lib/interfaces/message_types.ts
+++ b/packages/viber-adapter/lib/interfaces/message_types.ts
@@ -58,6 +58,7 @@ export interface IViberLocationMessage extends IViberMessage {
         lat: number;
         lon: number;
     };
+    text?: string;
 }
 
 export type MessageData =


### PR DESCRIPTION
# Add location message handler

## A quick explanation

In the simplest way possible we will handle messages containing location as a text message and adding the location as attributes to the tracking_data param.  So we can handle any location message containing text with adding a text rule action.

For location messages that do not contain any text (The user simple send his location with out pressing any of our buttons) a default text handler is set. 