### PR TITLE
Bug on importing and better Typing

### DIFF
--- a/examples/viber-demo-bot/src/modules/getStarted/actions.ts
+++ b/examples/viber-demo-bot/src/modules/getStarted/actions.ts
@@ -6,7 +6,8 @@ import {
     addPostbackRule,
     addTextRule,
     InMemoryUser,
-    addBaseLocationRule
+    addBaseLocationRule,
+    IPayload
 } from '@ebenos/framework';
 import getStartedModule from '.';
 
@@ -199,7 +200,7 @@ async function getTest12(user: InMemoryUser) {
 
 addAction(getStartedModule, location);
 addBaseLocationRule(getStartedModule, location);
-async function location(user: InMemoryUser, payload?: Record<string, any>) {
+async function location(user: InMemoryUser, payload?: IPayload) {
     await bot
         .scenario(user)
         .send(
@@ -247,7 +248,7 @@ async function location1(user: InMemoryUser) {
 
 addAction(getStartedModule, location2);
 addTextRule(getStartedModule, location2, /PAME/);
-async function location2(user: InMemoryUser, payload?: Record<string, any>) {
+async function location2(user: InMemoryUser, payload?: IPayload) {
     await bot
         .scenario(user)
         .send(

--- a/examples/viber-demo-bot/src/modules/getStarted/actions.ts
+++ b/examples/viber-demo-bot/src/modules/getStarted/actions.ts
@@ -200,7 +200,10 @@ async function getTest12(user: InMemoryUser) {
 
 addAction(getStartedModule, location);
 addBaseLocationRule(getStartedModule, location);
-async function location(user: InMemoryUser, payload?: IPayload) {
+async function location(
+    user: InMemoryUser,
+    payload?: { text: string; location?: { lat: number; lon: number }; somethingNew?: string }
+) {
     await bot
         .scenario(user)
         .send(

--- a/packages/framework/lib/bot.ts
+++ b/packages/framework/lib/bot.ts
@@ -18,6 +18,7 @@ import User from './models/User';
 import attachmentHandlerFactory from './handlers/attachment';
 import textHandlerFactory from './handlers/text';
 import nlpHandlerFactory from './handlers/nlp';
+import { IPayload } from './interfaces/payload';
 
 // Router Classes
 import PostbackRouter from './routers/PostbackRouter';
@@ -147,8 +148,8 @@ export default class Bot<U extends User<any>> {
         for (const r of rules) {
             textRules.push({
                 regex: r.regex,
-                action: (user: U, message?: Record<string, any>, ...args: any[]) =>
-                    bot.actions.exec(r.action, user, message, args)
+                action: (user: U, payload?: IPayload, ...args: any[]) =>
+                    bot.actions.exec(r.action, user, payload, args)
             });
         }
 

--- a/packages/framework/lib/index.ts
+++ b/packages/framework/lib/index.ts
@@ -20,6 +20,7 @@ export { ActionMiddleware } from './utilities/actions';
 export { IRouters, EbonyHandlers, IBaseMessage, IBaseMessageOptions } from './adapter';
 export { WitNLP } from './interfaces/nlp';
 export { GenericAttachment } from './interfaces/attachment';
+export { ITrackingData } from './interfaces/trackingData';
 export * from './interfaces/interactions';
 export * from './modules';
 

--- a/packages/framework/lib/index.ts
+++ b/packages/framework/lib/index.ts
@@ -21,6 +21,7 @@ export { IRouters, EbonyHandlers, IBaseMessage, IBaseMessageOptions } from './ad
 export { WitNLP } from './interfaces/nlp';
 export { GenericAttachment } from './interfaces/attachment';
 export { ITrackingData } from './interfaces/trackingData';
+export { IPayload } from './interfaces/payload';
 export * from './interfaces/interactions';
 export * from './modules';
 

--- a/packages/framework/lib/interfaces/payload.ts
+++ b/packages/framework/lib/interfaces/payload.ts
@@ -1,0 +1,7 @@
+import { ITrackingData } from './trackingData';
+export interface IPayload extends Record<string, any> {
+    text: string;
+    tracking_data?: ITrackingData;
+    location?: { lon: number; lat: number };
+    type?: string;
+}

--- a/packages/framework/lib/modules/index.ts
+++ b/packages/framework/lib/modules/index.ts
@@ -1,5 +1,6 @@
 import User from '../models/User';
 import { Module } from '../interfaces/bot';
+import { IPayload } from '../interfaces/payload';
 
 export function createModule<U extends User<any>>(name = 'global'): Module<U> {
     const module: Module<U> = {
@@ -71,14 +72,14 @@ export function addPostbackRule<U extends User<any>>(
 
 export function addBaseLocationRule<U extends User<any>>(
     module: Module<U>,
-    action: (user: U, message?: Record<string, any>, ...args: any[]) => Promise<any>
+    action: (user: U, payload?: IPayload, ...args: any[]) => Promise<any>
 ): void {
     return addTextRule<U>(module, action, /USER_SEND_LOCATION/);
 }
 
 export function addTextRule<U extends User<any>>(
     module: Module<U>,
-    action: (user: U, message?: Record<string, any>, ...args: any[]) => Promise<any>,
+    action: (user: U, payload?: IPayload, ...args: any[]) => Promise<any>,
     rule: RegExp | RegExp[]
 ): void {
     const actionName = module.name + '/' + action.name;

--- a/packages/framework/lib/routers/TextMatcher.ts
+++ b/packages/framework/lib/routers/TextMatcher.ts
@@ -7,10 +7,11 @@
  * @license MIT
  *
  */
+import { IPayload } from '../interfaces/payload';
 
 export interface ITextRule {
     regex: RegExp;
-    action: (user: any, message?: Record<string, any>, ...args: any[]) => any;
+    action: (user: any, payload?: IPayload, ...args: any[]) => any;
 }
 
 /**
@@ -28,7 +29,7 @@ export default class TextMatcher {
 
     public ruleMatcher(message: {
         text: string;
-    }): ((user: any, message?: Record<string, any>, ...args: any[]) => any) | false {
+    }): ((user: any, payload?: IPayload, ...args: any[]) => any) | false {
         const msg = message.text.toUpperCase();
         for (const rule of this.rules) {
             const { regex, action } = rule;

--- a/packages/viber-adapter/lib/adapter.ts
+++ b/packages/viber-adapter/lib/adapter.ts
@@ -12,7 +12,7 @@ import {
     IViberTextMessage
 } from './interfaces/message_types';
 import { isPostbackTrackingData } from './interfaces/tracking_data';
-import { ITrackingData } from '@ebenos/framework/lib/interfaces/trackingData';
+import { ITrackingData } from '@ebenos/framework';
 
 export interface IViberOptions {
     route?: string;

--- a/packages/viber-elements/lib/viberAPI/interfaces.ts
+++ b/packages/viber-elements/lib/viberAPI/interfaces.ts
@@ -1,7 +1,7 @@
 import { RichMedia, Picture, Button } from './attachments';
 import { Carousel } from './carousel';
 import { Keyboard } from './keyboard';
-import { ITrackingData } from '@ebenos/framework/lib/interfaces/trackingData';
+import { ITrackingData } from '@ebenos/framework';
 
 export type ScaleType = 'crop' | 'fill' | 'fit';
 export type ActionType = 'reply' | 'open-url' | 'location-picker' | 'share-phone' | 'none';

--- a/packages/viber-elements/lib/viberAPI/message.ts
+++ b/packages/viber-elements/lib/viberAPI/message.ts
@@ -12,7 +12,7 @@ import {
 import { Picture, RichMedia } from './attachments';
 import { Keyboard } from './keyboard';
 import { Carousel } from './carousel';
-import { ITrackingData } from '@ebenos/framework/lib/interfaces/trackingData';
+import { ITrackingData } from '@ebenos/framework';
 
 function isText(options: IMessageOptions): options is ITextOptions {
     return (options as ITextOptions).text !== undefined;


### PR DESCRIPTION
1. Fix Bug of wrong import
`import { ITrackingData } from '@ebenos/framework/lib/interfaces/trackingData';`
by exporting from the framework the ITrackingData

2. 
- Rename the second argument of an action function to `payload` instead of `message` 
- And created an interface for this payload that it is more explanatory from just `Record<string, any>`
 to `interface IPayload extends Record<string, any> {
    text: string;
    tracking_data?: ITrackingData;
    location?: { lon: number; lat: number };
    type?: string;
}`